### PR TITLE
refactor: Move conversion functions to a separate module for better o…

### DIFF
--- a/cli/templates/operator/controller.rs.jinja
+++ b/cli/templates/operator/controller.rs.jinja
@@ -33,41 +33,6 @@ const REQUEUE_AFTER_IN_SEC: u64 = 30;
 const API_URL: &str = "{{ api_url }}";
 const API_USER_AGENT: &str = "k8s-operator";
 
-fn convert_{{ resource_remote_ref }}_to_string({{ resource_remote_ref }}: Option<{{ resource_remote_ref }}::Uuid>) -> Option<String> {
-    {{ resource_remote_ref }}.map(|{{ resource_remote_ref }}| {{ resource_remote_ref }}.to_string())
-}
-
-fn convert_string_to_{{ resource_remote_ref }}({{ resource_remote_ref }}: Option<String>) -> Option<{{ resource_remote_ref }}::Uuid> {
-    match {{ resource_remote_ref }} {
-        Some({{ resource_remote_ref }}) => match {{ resource_remote_ref }}::Uuid::parse_str(&{{ resource_remote_ref }}) {
-            Ok({{ resource_remote_ref }}) => Some({{ resource_remote_ref }}),
-            Err(_) => None,
-        },
-        None => None,
-    }
-}
-
-fn convert_kube_type_to_dto({{ arg_name }}: {{ kind_struct }}) -> {{ kind_struct }}Dto {
-    let {{ resource_remote_ref }} = match {{ arg_name }}.status {
-        Some(status) => convert_string_to_{{ resource_remote_ref }}(status.{{ resource_remote_ref }}),
-        None => None,
-    };
-    {{ kind_struct }}Dto {
-        {{ resource_remote_ref}},
-        {%- for field in dto_fields %}
-            {{ field.pub_name }}: {{ arg_name }}.spec.{{ field.pub_name }},
-        {%- endfor %}
-    }
-}
-
-fn convert_dto_to_kube_type({{ arg_name }}: {{ kind_struct }}Dto) -> {{ kind_struct }}Spec {
-    {{ kind_struct }}Spec {
-    {%- for field in dto_fields %}
-        {{ field.pub_name }}: {{ arg_name }}.{{ field.pub_name }},
-    {%- endfor %}
-    }
-}
-
 struct ExtraArgs {
     kube_client: Api<{{ kind_struct }}>,
 }
@@ -146,8 +111,8 @@ pub async fn check_for_drift(
     kube_client: &Api<{{ kind_struct }}>,
     {{ arg_name }}: &mut {{ kind_struct }},
 ) -> Result<(), OperatorError> {
-    let dto = convert_kube_type_to_dto({{ arg_name }}.clone());
-    let {{ resource_remote_ref }} = convert_{{ resource_remote_ref }}_to_string(dto.{{ resource_remote_ref }}).unwrap_or_default();
+    let dto = converters::kube_type_to_dto({{ arg_name }}.clone());
+    let {{ resource_remote_ref }} = converters::{{ resource_remote_ref }}_to_string(dto.{{ resource_remote_ref }}).unwrap_or_default();
     let config = get_client_config().await?;
 
     if {{ resource_remote_ref }}.is_empty() {
@@ -157,9 +122,9 @@ pub async fn check_for_drift(
 
     match get_{{ arg_name }}_by_id(&config, &{{ resource_remote_ref }}).await {
         Ok(dto) => {
-            let remote_{{ arg_name }} = convert_dto_to_kube_type(dto);
+            let remote_{{ arg_name }} = converters::dto_to_kube_type(dto);
             if remote_{{ arg_name }} != {{ arg_name }}.spec {
-                let current_{{ arg_name }}_dto = convert_kube_type_to_dto({{ arg_name }}.clone());
+                let current_{{ arg_name }}_dto = converters::kube_type_to_dto({{ arg_name }}.clone());
                 warn!("{{ kind_struct }} has drifted remotely, sending an update to remote...");
                 match update_{{ arg_name }}_by_id(&config, &{{ resource_remote_ref }}, current_{{ arg_name }}_dto).await {
                     Ok(_) => {
@@ -197,4 +162,45 @@ pub async fn check_for_drift(
 fn error_policy(_resource: Arc<{{ kind_struct }}>, error: &OperatorError, _ctx: Arc<ExtraArgs>) -> Action {
     error!("Error processing event: {:?}", error);
     Action::requeue(Duration::from_secs(REQUEUE_AFTER_IN_SEC))
+}
+
+mod converters {
+    use super::{
+        {{ kind_struct }}, {{ kind_struct }}Dto, {{ kind_struct }}Spec
+    };
+
+    pub fn {{ resource_remote_ref }}_to_string({{ resource_remote_ref }}: Option<{{ resource_remote_ref }}::Uuid>) -> Option<String> {
+        {{ resource_remote_ref }}.map(|{{ resource_remote_ref }}| {{ resource_remote_ref }}.to_string())
+    }
+
+    fn string_to_{{ resource_remote_ref }}({{ resource_remote_ref }}: Option<String>) -> Option<{{ resource_remote_ref }}::Uuid> {
+        match {{ resource_remote_ref }} {
+            Some({{ resource_remote_ref }}) => match {{ resource_remote_ref }}::Uuid::parse_str(&{{ resource_remote_ref }}) {
+                Ok({{ resource_remote_ref }}) => Some({{ resource_remote_ref }}),
+                Err(_) => None,
+            },
+            None => None,
+        }
+    }
+
+    pub fn kube_type_to_dto({{ arg_name }}: {{ kind_struct }}) -> {{ kind_struct }}Dto {
+        let {{ resource_remote_ref }} = match {{ arg_name }}.status {
+            Some(status) => string_to_{{ resource_remote_ref }}(status.{{ resource_remote_ref }}),
+            None => None,
+        };
+        {{ kind_struct }}Dto {
+            {{ resource_remote_ref}},
+            {%- for field in dto_fields %}
+                {{ field.pub_name }}: {{ arg_name }}.spec.{{ field.pub_name }},
+            {%- endfor %}
+        }
+    }
+
+    pub fn dto_to_kube_type({{ arg_name }}: {{ kind_struct }}Dto) -> {{ kind_struct }}Spec {
+        {{ kind_struct }}Spec {
+        {%- for field in dto_fields %}
+            {{ field.pub_name }}: {{ arg_name }}.{{ field.pub_name }},
+        {%- endfor %}
+        }
+    }
 }

--- a/cli/templates/operator/controller_action_create.jinja
+++ b/cli/templates/operator/controller_action_create.jinja
@@ -1,13 +1,13 @@
 {% for controller in controllers %}
     {% if controller.http_method == "post" %}
 pub async fn handle_create(kube_client: &Api<{{ kind_struct }}>, {{ arg_name }}: &mut {{ kind_struct }}) -> Result<(), OperatorError> {
-    let dto = convert_kube_type_to_dto({{ arg_name }}.clone());
+    let dto = converters::kube_type_to_dto({{ arg_name }}.clone());
     let config = get_client_config().await?;
 
     match create_{{ arg_name }}(&config, dto.clone()).await {
         Ok(remote_{{ arg_name }}) => {
             if let Some({{ resource_remote_ref }}) = remote_{{ arg_name }}.{{ resource_remote_ref }} {
-                let {{ resource_remote_ref }} = convert_{{ resource_remote_ref }}_to_string(Some({{ resource_remote_ref }})).unwrap();
+                let {{ resource_remote_ref }} = converters::{{ resource_remote_ref }}_to_string(Some({{ resource_remote_ref }})).unwrap();
                 add_finalizer({{ arg_name }}, kube_client.clone()).await?;
                 let generation = {{ arg_name }}.meta().generation;
                 let condition = create_condition(

--- a/cli/templates/operator/controller_action_update.jinja
+++ b/cli/templates/operator/controller_action_update.jinja
@@ -5,7 +5,7 @@ pub async fn handle_update(
     {{ arg_name }}: &mut {{ kind_struct }},
     {{ resource_remote_ref }}: &str,
 ) -> Result<(), OperatorError> {
-    let dto = convert_kube_type_to_dto({{ arg_name }}.clone());
+    let dto = converters::kube_type_to_dto({{ arg_name }}.clone());
     let config = get_client_config().await?;
 
     if {{ resource_remote_ref }}.is_empty() {

--- a/cli/tests/snapshot/snapshots/snapshot__templates_operator_controller__render.snap
+++ b/cli/tests/snapshot/snapshots/snapshot__templates_operator_controller__render.snap
@@ -37,39 +37,6 @@ const REQUEUE_AFTER_IN_SEC: u64 = 30;
 const API_URL: &str = "https://api.example.com";
 const API_USER_AGENT: &str = "k8s-operator";
 
-fn convert_resourceRef_to_string(resourceRef: Option<resourceRef::Uuid>) -> Option<String> {
-    resourceRef.map(|resourceRef| resourceRef.to_string())
-}
-
-fn convert_string_to_resourceRef(resourceRef: Option<String>) -> Option<resourceRef::Uuid> {
-    match resourceRef {
-        Some(resourceRef) => match resourceRef::Uuid::parse_str(&resourceRef) {
-            Ok(resourceRef) => Some(resourceRef),
-            Err(_) => None,
-        },
-        None => None,
-    }
-}
-
-fn convert_kube_type_to_dto(argName: ExampleKind) -> ExampleKindDto {
-    let resourceRef = match argName.status {
-        Some(status) => convert_string_to_resourceRef(status.resourceRef),
-        None => None,
-    };
-    ExampleKindDto {
-        resourceRef,
-            field1: argName.spec.field1,
-            field2: argName.spec.field2,
-    }
-}
-
-fn convert_dto_to_kube_type(argName: ExampleKindDto) -> ExampleKindSpec {
-    ExampleKindSpec {
-        field1: argName.field1,
-        field2: argName.field2,
-    }
-}
-
 struct ExtraArgs {
     kube_client: Api<ExampleKind>,
 }
@@ -148,8 +115,8 @@ pub async fn check_for_drift(
     kube_client: &Api<ExampleKind>,
     argName: &mut ExampleKind,
 ) -> Result<(), OperatorError> {
-    let dto = convert_kube_type_to_dto(argName.clone());
-    let resourceRef = convert_resourceRef_to_string(dto.resourceRef).unwrap_or_default();
+    let dto = converters::kube_type_to_dto(argName.clone());
+    let resourceRef = converters::resourceRef_to_string(dto.resourceRef).unwrap_or_default();
     let config = get_client_config().await?;
 
     if resourceRef.is_empty() {
@@ -159,9 +126,9 @@ pub async fn check_for_drift(
 
     match get_argName_by_id(&config, &resourceRef).await {
         Ok(dto) => {
-            let remote_argName = convert_dto_to_kube_type(dto);
+            let remote_argName = converters::dto_to_kube_type(dto);
             if remote_argName != argName.spec {
-                let current_argName_dto = convert_kube_type_to_dto(argName.clone());
+                let current_argName_dto = converters::kube_type_to_dto(argName.clone());
                 warn!("ExampleKind has drifted remotely, sending an update to remote...");
                 match update_argName_by_id(&config, &resourceRef, current_argName_dto).await {
                     Ok(_) => {
@@ -199,4 +166,43 @@ pub async fn check_for_drift(
 fn error_policy(_resource: Arc<ExampleKind>, error: &OperatorError, _ctx: Arc<ExtraArgs>) -> Action {
     error!("Error processing event: {:?}", error);
     Action::requeue(Duration::from_secs(REQUEUE_AFTER_IN_SEC))
+}
+
+mod converters {
+    use super::{
+        ExampleKind, ExampleKindDto, ExampleKindSpec
+    };
+
+    pub fn resourceRef_to_string(resourceRef: Option<resourceRef::Uuid>) -> Option<String> {
+        resourceRef.map(|resourceRef| resourceRef.to_string())
+    }
+
+    fn string_to_resourceRef(resourceRef: Option<String>) -> Option<resourceRef::Uuid> {
+        match resourceRef {
+            Some(resourceRef) => match resourceRef::Uuid::parse_str(&resourceRef) {
+                Ok(resourceRef) => Some(resourceRef),
+                Err(_) => None,
+            },
+            None => None,
+        }
+    }
+
+    pub fn kube_type_to_dto(argName: ExampleKind) -> ExampleKindDto {
+        let resourceRef = match argName.status {
+            Some(status) => string_to_resourceRef(status.resourceRef),
+            None => None,
+        };
+        ExampleKindDto {
+            resourceRef,
+                field1: argName.spec.field1,
+                field2: argName.spec.field2,
+        }
+    }
+
+    pub fn dto_to_kube_type(argName: ExampleKindDto) -> ExampleKindSpec {
+        ExampleKindSpec {
+            field1: argName.field1,
+            field2: argName.field2,
+        }
+    }
 }


### PR DESCRIPTION
This pull request refactors the code by consolidating conversion functions into a new `converters` module and updating references to these functions throughout the codebase. The main goal is to improve code organization and readability.

Refactoring and code organization:

* Moved conversion functions to a new `converters` module and updated all references to these functions in `cli/templates/operator/controller.rs.jinja` [[1]](diffhunk://#diff-411d38afa087baa49f92c90a95c189de10f34e4ed7354b1af4b224f556e3fbf3L36-L70) [[2]](diffhunk://#diff-411d38afa087baa49f92c90a95c189de10f34e4ed7354b1af4b224f556e3fbf3L149-R115) [[3]](diffhunk://#diff-411d38afa087baa49f92c90a95c189de10f34e4ed7354b1af4b224f556e3fbf3L160-R127) [[4]](diffhunk://#diff-411d38afa087baa49f92c90a95c189de10f34e4ed7354b1af4b224f556e3fbf3R166-R206).
* Updated conversion function references in `cli/templates/operator/controller_action_create.jinja`.
* Updated conversion function references in `cli/templates/operator/controller_action_update.jinja`.

Snapshot updates:

* Updated snapshot tests to reflect the changes in conversion function references in `cli/tests/snapshot/snapshots/snapshot__templates_operator_controller__render.snap` [[1]](diffhunk://#diff-2071cf3257623796e0693c6f571a7f0f519309b54016ae62e853c790e098663aL40-L72) [[2]](diffhunk://#diff-2071cf3257623796e0693c6f571a7f0f519309b54016ae62e853c790e098663aL151-R119) [[3]](diffhunk://#diff-2071cf3257623796e0693c6f571a7f0f519309b54016ae62e853c790e098663aL162-R131) [[4]](diffhunk://#diff-2071cf3257623796e0693c6f571a7f0f519309b54016ae62e853c790e098663aR170-R208).


Closes #43 